### PR TITLE
dependency 수정 및 deprecated 해결

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ subprojects {
         testImplementation("org.slf4j:slf4j-api:1.7.25")
         testImplementation("org.apache.logging.log4j:log4j-core:2.8.2")
         testImplementation("org.apache.logging.log4j:log4j-slf4j-impl:2.8.2")
-        testImplementation("org.spigotmc:spigot:1.16.3-R0.1-SNAPSHOT")
+        testImplementation("com.destroystokyo.paper:paper-api:1.16.3-R0.1-SNAPSHOT")
     }
 
     tasks {

--- a/psychics-common/src/main/kotlin/com/github/noonmaru/psychics/AbilityConcept.kt
+++ b/psychics-common/src/main/kotlin/com/github/noonmaru/psychics/AbilityConcept.kt
@@ -235,7 +235,7 @@ open class AbilityConcept {
     }
 
     internal fun createAbilityInstance(): Ability<*> {
-        return container.abilityClass.newInstance().apply {
+        return container.abilityClass.getDeclaredConstructor().newInstance().apply {
             initConcept(this@AbilityConcept)
         }
     }

--- a/psychics-common/src/main/kotlin/com/github/noonmaru/psychics/PsychicManager.kt
+++ b/psychics-common/src/main/kotlin/com/github/noonmaru/psychics/PsychicManager.kt
@@ -211,7 +211,7 @@ class PsychicManager(
                     if (containers.count() > 1) error("Ambiguous Ability ${containers.joinToString { it.description.artifactId }}")
 
                     val abilityContainer = containers.first()
-                    val abilityConcept = abilityContainer.conceptClass.newInstance()
+                    val abilityConcept = abilityContainer.conceptClass.getDeclaredConstructor().newInstance()
                     changed = changed or abilityConcept.initialize(abilityName, abilityContainer, psychicConcept, value)
                     abilityConcepts += abilityConcept
                 }

--- a/psychics-common/src/main/kotlin/com/github/noonmaru/psychics/loader/AbilityClassLoader.kt
+++ b/psychics-common/src/main/kotlin/com/github/noonmaru/psychics/loader/AbilityClassLoader.kt
@@ -21,6 +21,8 @@ import java.io.File
 import java.net.URLClassLoader
 import java.util.concurrent.ConcurrentHashMap
 
+import kotlin.jvm.Throws
+
 internal class AbilityClassLoader(
     private val loader: AbilityLoader,
     file: File,

--- a/psychics-common/src/main/kotlin/com/github/noonmaru/psychics/loader/AbilityLoader.kt
+++ b/psychics-common/src/main/kotlin/com/github/noonmaru/psychics/loader/AbilityLoader.kt
@@ -24,6 +24,7 @@ import com.github.noonmaru.psychics.AbilityDescription
 import java.io.File
 import java.util.concurrent.ConcurrentHashMap
 
+import kotlin.jvm.Throws
 
 class AbilityLoader internal constructor() {
     private val classes: MutableMap<String, Class<*>?> = ConcurrentHashMap()

--- a/psychics-common/src/main/kotlin/com/github/noonmaru/psychics/loader/AbilityLoader.kt
+++ b/psychics-common/src/main/kotlin/com/github/noonmaru/psychics/loader/AbilityLoader.kt
@@ -88,7 +88,7 @@ class AbilityLoader internal constructor() {
 
 private fun <T> testCreateInstance(clazz: Class<T>): T {
     try {
-        return clazz.newInstance()
+        return clazz.getDeclaredConstructor().newInstance()
     } catch (e: Exception) {
         error("Failed to create instance ${clazz.name}")
     }


### PR DESCRIPTION
repository를 github desktop을 통해 가져온 후, intellij idea (ultimate)에서 open을 통해 가져오면 아래와 같은 오류가 나옵니다.
![image](https://user-images.githubusercontent.com/56160437/95278321-eaa31f00-088a-11eb-93c3-af8863da7549.png)
이에 대한 해결법으로, build.gradle에 spigot에 대한 maven을 추가하거나, spigot implementation을 paper로 변경하는 방법이 있는데, 후자를 적용하였습니다.

또, 변경하면서 Class.newInstance()가 deprecated로 표시됨에 따라 Class.getDeclaredConstructor().newInstance()로 변경하였습니다.

마지막으로, 사소한 건이지만 IDE에서 com.github.noonmaru.psychics.loader의 두 파일에 대해 @Throws어노테이션 에서 import가 필요하다고 출력하여 kotlin.jvm.Throws를 import하였습니다. 

paper-216으로 버킷을 열어 테스트해본 결과, 버킷 실행은 문제없이 되었습니다. 인게임 테스트는 실행한 다음 내용 수정하도록 하겠습니다.